### PR TITLE
speed up gffutils

### DIFF
--- a/peaks2utr/__init__.py
+++ b/peaks2utr/__init__.py
@@ -51,6 +51,10 @@ def prepare_argparser():
                         help="annotate 3' UTR also for pseudogenic transcripts.")
     parser.add_argument('--no-strand-overlap', action="store_true",
                         help="Prevent overlapping of new UTR feature with any feature on other strand (truncating if necessary).")
+    parser.add_argument('--disable-infer-genes', action="store_true",
+                        help="Disable gffutils gene inference when creating the annotation database. Default: False")
+    parser.add_argument('--disable-infer-transcripts', action="store_true",
+                        help="Disable gffutils transcript inference when creating the annotation database. Default: False")
     parser.add_argument('-p', '--processors', type=int, default=1, help="how many processor cores to use. Default: 1")
     parser.add_argument('-f', '-force', '--force', action="store_true", help="overwrite outputs if they exist")
     parser.add_argument('-o', '--output', help="output filename. Defaults to <GFF_IN basename>.new.<ext>")
@@ -171,7 +175,7 @@ async def _main(args):
         BAMSplitter(bam_basename, args).process()
 
         db, _, _ = await asyncio.gather(
-            create_db(args.GFF_IN),
+            create_db(args.GFF_IN, args.disable_infer_genes, args.disable_infer_transcripts),
             call_peaks(bam_basename, "forward"),
             call_peaks(bam_basename, "reverse")
         )

--- a/peaks2utr/preprocess.py
+++ b/peaks2utr/preprocess.py
@@ -143,7 +143,7 @@ class BAMSplitter:
         gaps.saveas(cached(output_file))
 
 
-async def create_db(gff_in):
+async def create_db(gff_in, disable_infer_genes=False, disable_infer_transcripts=False):
     """
     Asynchronously create sqlite3 db for GFF_IN.
     """
@@ -151,7 +151,9 @@ async def create_db(gff_in):
     if not os.path.isfile(gff_db):
         logging.info('Creating gff db.')
         await sync_to_async(gffutils.create_db)(
-            gff_in, gff_db, force=True, verbose=True, merge_strategy="create_unique")
+            gff_in, gff_db, force=True, verbose=True, merge_strategy="create_unique",
+            disable_infer_genes=disable_infer_genes,
+            disable_infer_transcripts=disable_infer_transcripts)
         logging.info('Finished creating gff db.')
     else:
         logging.info("Using cached gff db.")

--- a/tests/create_db/test_create_db_options.py
+++ b/tests/create_db/test_create_db_options.py
@@ -1,0 +1,53 @@
+import asyncio
+import os.path
+import unittest
+from unittest.mock import patch
+
+from peaks2utr import prepare_argparser
+from peaks2utr.preprocess import create_db
+
+
+class TestCreateDBOptions(unittest.TestCase):
+    def test_infer_options_default_to_false(self):
+        args = prepare_argparser().parse_args(["annotations.gtf", "reads.bam"])
+
+        self.assertFalse(args.disable_infer_genes)
+        self.assertFalse(args.disable_infer_transcripts)
+
+    def test_infer_options_are_parsed(self):
+        args = prepare_argparser().parse_args([
+            "annotations.gtf",
+            "reads.bam",
+            "--disable-infer-genes",
+            "--disable-infer-transcripts",
+        ])
+
+        self.assertTrue(args.disable_infer_genes)
+        self.assertTrue(args.disable_infer_transcripts)
+
+    def test_create_db_passes_infer_options_to_gffutils(self):
+        db_path = os.path.join("cache", "annotations.db")
+
+        with patch("peaks2utr.preprocess.cached", return_value=db_path):
+            with patch("peaks2utr.preprocess.os.path.isfile", return_value=False):
+                with patch("peaks2utr.preprocess.gffutils.create_db") as mock_create_db:
+                    result = asyncio.run(create_db(
+                        "annotations.gtf",
+                        disable_infer_genes=True,
+                        disable_infer_transcripts=True,
+                    ))
+
+        self.assertEqual(result, db_path)
+        mock_create_db.assert_called_once_with(
+            "annotations.gtf",
+            db_path,
+            force=True,
+            verbose=True,
+            merge_strategy="create_unique",
+            disable_infer_genes=True,
+            disable_infer_transcripts=True,
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/create_db/test_disable_infer_features.py
+++ b/tests/create_db/test_disable_infer_features.py
@@ -18,6 +18,7 @@ class TestDisableInferFeatures(unittest.TestCase):
         self.db1_path = os.path.join(TEST_DIR, "case3.no_parent.1.db")
         self.db2_path = os.path.join(TEST_DIR, "case3.no_parent.2.db")
         self.db3_path = os.path.join(TEST_DIR, "case3.no_parent.3.db")
+        self.db4_path = os.path.join(TEST_DIR, "case3.with_parent.no_infer.db")
         gffutils.create_db(os.path.join(TEST_DIR, "case3.no_parent.gtf"), self.db1_path, force=True, merge_strategy="create_unique",
                            disable_infer_genes=True,
                            disable_infer_transcripts=True)
@@ -27,9 +28,13 @@ class TestDisableInferFeatures(unittest.TestCase):
         gffutils.create_db(os.path.join(TEST_DIR, "case3.no_parent.gtf"), self.db3_path, force=True, merge_strategy="create_unique",
                            disable_infer_genes=False,
                            disable_infer_transcripts=False)
+        gffutils.create_db(os.path.join(TEST_DIR, "case3.gtf"), self.db4_path, force=True, merge_strategy="create_unique",
+                           disable_infer_genes=True,
+                           disable_infer_transcripts=True)
         self.db1 = FeatureDB(self.db1_path)
         self.db2 = FeatureDB(self.db2_path)
         self.db3 = FeatureDB(self.db3_path)
+        self.db4 = FeatureDB(self.db4_path)
         self.coverage_gaps = ZeroCoverageIntervalsDict()
         self.truncation_points = SPATTruncationPointsDict()
         forward_peaks_filename = os.path.join(TEST_DIR, "forward_peaks.broadPeak")
@@ -43,6 +48,7 @@ class TestDisableInferFeatures(unittest.TestCase):
         os.remove(self.db1_path)
         os.remove(self.db2_path)
         os.remove(self.db3_path)
+        os.remove(self.db4_path)
     
     def _annotate_db(self, db):
         self.args.max_distance = 5000
@@ -59,6 +65,10 @@ class TestDisableInferFeatures(unittest.TestCase):
         
         # UTR is correctly annotated when disable_infer_genes and disable_infer_transcripts are both False
         self.assertIn("ENSMUSG00000112145", self._annotate_db(self.db3))
+
+    def test_utr_annotation_with_explicit_parents_without_inference(self):
+        # UTR is correctly annotated when parent gene and transcript features exist
+        self.assertIn("ENSMUSG00000112145", self._annotate_db(self.db4))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
added 'disable_infer_genes' and 'disable_infer_transcripts' to 'create_db'
I'm not sure if this will be problematic under different scenarios, but this sped up my peaks2utr command by about 10-fold, from 6 hours to ~35 minutes.
This is my first pull request, and I'm not too familiar w/ python, so I apologize if anything looks wrong/this was too small for a pull request.

Cheers!